### PR TITLE
Fix path validation and provide sync API

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -31,7 +31,7 @@ async def compress_project():
     )
     
     # Process codebase
-    output_files = await pipeline.process_codebase(
+    output_files = await pipeline.process_codebase_async(
         codebase_path=Path('./my_project'),
         output_format='markdown'  # or 'json', 'xml'
     )
@@ -95,7 +95,7 @@ output_files = await pipeline.process_codebase_resilient(
 ### 3. With Custom Ignore Patterns
 
 ```python
-output_files = await pipeline.process_codebase(
+output_files = await pipeline.process_codebase_async(
     codebase_path=Path('./my_project'),
     ignore_patterns=[
         'node_modules',
@@ -112,7 +112,7 @@ output_files = await pipeline.process_codebase(
 
 ```python
 # Process only Python files with high complexity
-output_files = await pipeline.process_codebase(
+output_files = await pipeline.process_codebase_async(
     codebase_path=Path('./my_project'),
     query_filter={
         'language': 'python',
@@ -187,7 +187,7 @@ monitor = PipelineMonitor()
 monitor.start_monitoring()
 
 # Process with monitoring
-await pipeline.process_codebase(Path('./project'))
+await pipeline.process_codebase_async(Path('./project'))
 
 # Get performance metrics
 metrics = monitor.get_summary()

--- a/compress.sh
+++ b/compress.sh
@@ -137,7 +137,7 @@ async def main():
     ]
     
     # Process codebase
-    output_files = await pipeline.process_codebase(
+    output_files = await pipeline.process_codebase_async(
         codebase_path=codebase_path,
         output_format=output_format,
         compression_strategy=compression_strategy,

--- a/pipeline_architecture.md
+++ b/pipeline_architecture.md
@@ -344,7 +344,7 @@ chunk_strategy = 'semantic'  # or 'size', 'balanced'
 ### 1. Full Codebase Analysis
 ```python
 # Process entire codebase with structural compression
-output = await pipeline.process_codebase(
+output = await pipeline.process_codebase_async(
     codebase_path=Path('./project'),
     compression_strategy='structural'
 )
@@ -353,7 +353,7 @@ output = await pipeline.process_codebase(
 ### 2. Targeted Extraction
 ```python
 # Extract only complex Python files
-output = await pipeline.process_codebase(
+output = await pipeline.process_codebase_async(
     codebase_path=Path('./project'),
     query_filter={
         'language': 'python',
@@ -366,7 +366,7 @@ output = await pipeline.process_codebase(
 ### 3. Dependency Analysis
 ```python
 # Find all files importing specific module
-output = await pipeline.process_codebase(
+output = await pipeline.process_codebase_async(
     codebase_path=Path('./project'),
     query_filter={
         'imports': 'tensorflow'
@@ -379,7 +379,7 @@ output = await pipeline.process_codebase(
 ```python
 # Process only changes since last run
 pipeline.cache.cleanup_expired()  # Clean old entries
-output = await pipeline.process_codebase(
+output = await pipeline.process_codebase_async(
     codebase_path=Path('./project'),
     compression_strategy='structural'
 )
@@ -393,7 +393,7 @@ output = await pipeline.process_codebase(
 pipeline.optimizer.profiling_enabled = True
 
 # Process codebase
-await pipeline.process_codebase(...)
+await pipeline.process_codebase_async(...)
 
 # Get performance report
 report = pipeline.optimizer.get_performance_report()


### PR DESCRIPTION
## Summary
- relax path validation for non-existent directories
- allow external cache directories when validated
- expose a synchronous `process_codebase` API
- rename async version to `process_codebase_async`
- update scripts and docs for the new API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a366eb1688320883a77bff3939667